### PR TITLE
Add Try utility

### DIFF
--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/DiceServiceImpl.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/DiceServiceImpl.java
@@ -13,15 +13,13 @@ public class DiceServiceImpl implements DiceService {
 
     @Override
     public int[] twice() {
-        return JsonSerializer.deserialize(
-                httpClient.get("/bdd/game/0/dice").get(),
-                Dice.class
-        )
+        return httpClient.get("/bdd/game/0/dice")
+                .flatMap(json -> JsonSerializer.deserialize(json, DiceWrapper.class))
                 .map(d -> d.dice)
-                .orElseGet(() -> new int[]{0, 0});
+                .orElseGet(new int[]{0, 0});
     }
 
-    private static final class Dice {
+    private static final class DiceWrapper {
         public int[] dice;
     }
 

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/EntryServiceImpl.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/EntryServiceImpl.java
@@ -14,9 +14,8 @@ public class EntryServiceImpl implements EntryService {
 
     @Override
     public boolean create(String userNames) {
-        return httpClient.put(
-                "/bdd/game/new",
-                new UserNames(userNames.trim().split("\n")));
+        UserNames names = new UserNames(userNames.trim().split("\n"));
+        return httpClient.put("/bdd/game/new", names);
     }
 
     public static final class UserNames {

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/GameStateServiceImpl.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/GameStateServiceImpl.java
@@ -21,6 +21,7 @@ public class GameStateServiceImpl implements GameStateService {
     public GameState getInit(String userNames) {
         GameState gameState = new GameState();
         gameState.setPlayers(createPlayers(userNames.trim().split("\n")));
+        // FIXME Don't use StubData
         gameState.setBoard(StubData.createBoard());
         return gameState;
     }
@@ -36,17 +37,13 @@ public class GameStateServiceImpl implements GameStateService {
 
     @Override
     public GameState get() {
-        return JsonSerializer.deserialize(
-                httpClient.get("/bdd/game/0/state").get(),
-                GameState.class
-        )
-                .orElseThrow(() -> new RuntimeException("GameState is not found."));
+        return httpClient.get("/bdd/game/0/state")
+                .flatMap(json -> JsonSerializer.deserialize(json, GameState.class))
+                .orElseThrow((e) -> new RuntimeException("GameState is not found.", e));
     }
 
     @Override
     public boolean update(GameState gameState) {
-        return httpClient.put(
-                "/bdd/game/0/state",
-                gameState);
+        return httpClient.put("/bdd/game/0/state", gameState);
     }
 }

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/HttpClientImpl.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/HttpClientImpl.java
@@ -4,34 +4,30 @@ import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.Response;
 import io.github.aosn.camp2016.ui.Config;
 import io.github.aosn.camp2016.ui.service.HttpClient;
+import io.github.aosn.util.tryable.Try;
+import io.github.aosn.util.tryable.Tryable;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-public class HttpClientImpl implements HttpClient {
+public class HttpClientImpl implements HttpClient, Tryable {
 
     private static AsyncHttpClient client = new AsyncHttpClient();
 
-    public Optional<String> get(String url) {
+    public Try<String> get(String url) {
         return get(url, Collections.emptyMap());
     }
 
-    public Optional<String> get(String url, Map<String, ?> params) {
-        try {
+    public Try<String> get(String url, Map<String, ?> params) {
+        return Try(() -> {
             AsyncHttpClient.BoundRequestBuilder builder = client.prepareGet(Config.getApiEndPoint() + url);
             for (Map.Entry<String, ?> p : params.entrySet()) {
                 JsonSerializer.serialize(p.getValue()).map(json -> builder.addQueryParam(p.getKey(), json));
             }
             Future<Response> f = builder.execute();
-            return Optional.of(f.get().getResponseBody());
-        } catch (IOException | ExecutionException | InterruptedException e) {
-            e.printStackTrace();
-        }
-        return Optional.empty();
+            return f.get().getResponseBody();
+        });
     }
 
     // XXX The body is nothing
@@ -49,6 +45,5 @@ public class HttpClientImpl implements HttpClient {
         String names = "mikan\nakari";
 
         System.out.println(JsonSerializer.serialize(new EntryServiceImpl.UserNames(names.trim().split("\n"))));
-//        get("", )
     }
 }

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/HttpClientMock.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/HttpClientMock.java
@@ -1,28 +1,31 @@
 package io.github.aosn.camp2016.ui.logic;
 
 import io.github.aosn.camp2016.ui.service.HttpClient;
+import io.github.aosn.util.tryable.Try;
+import io.github.aosn.util.tryable.Tryable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
-public class HttpClientMock implements HttpClient {
+public class HttpClientMock implements HttpClient, Tryable {
 
     private static Map<String, String> internalStorage = new HashMap<>();
 
     @Override
-    public Optional<String> get(String url) {
-        return Optional.ofNullable(internalStorage.get(url));
+    public Try<String> get(String url) {
+        return Try(() -> Optional.ofNullable(internalStorage.get(url)).orElseThrow(() -> new NoSuchElementException(url)));
     }
 
     @Override
-    public Optional<String> get(String url, Map<String, ?> params) {
-        throw new UnsupportedOperationException("Mock get can't use params");
+    public Try<String> get(String url, Map<String, ?> params) {
+        return Failed(new UnsupportedOperationException("Mock get can't use params"));
     }
 
     @Override
     public boolean put(String url, Object params) {
-        JsonSerializer.serialize(params).ifPresent(json -> internalStorage.put(url, json));
+        JsonSerializer.serialize(params).forEach(json -> internalStorage.put(url, json));
         return true;
     }
 

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/logic/JsonSerializer.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/logic/JsonSerializer.java
@@ -1,30 +1,17 @@
 package io.github.aosn.camp2016.ui.logic;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
-import java.util.Optional;
+import io.github.aosn.util.tryable.Try;
 
 public class JsonSerializer {
-    private static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public static Optional<String> serialize(Object o) {
-        try {
-            return Optional.of(MAPPER.writeValueAsString(o));
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-        return Optional.empty();
+    public static Try<String> serialize(Object o) {
+        return Try.to(() -> MAPPER.writeValueAsString(o));
     }
 
-    public static <T> Optional<T> deserialize(String json, Class<T> dto) {
-        try {
-            return Optional.of(MAPPER.readValue(json, dto));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return Optional.empty();
+    public static <T> Try<T> deserialize(String json, Class<T> dto) {
+        return Try.to(() -> MAPPER.readValue(json, dto));
     }
 
     private JsonSerializer() {

--- a/ui/src/main/java/io/github/aosn/camp2016/ui/service/HttpClient.java
+++ b/ui/src/main/java/io/github/aosn/camp2016/ui/service/HttpClient.java
@@ -1,10 +1,11 @@
 package io.github.aosn.camp2016.ui.service;
 
+import io.github.aosn.util.tryable.Try;
+
 import java.util.Map;
-import java.util.Optional;
 
 public interface HttpClient {
-    Optional<String> get(String url);
-    Optional<String> get(String url, Map<String, ?> params);
+    Try<String> get(String url);
+    Try<String> get(String url, Map<String, ?> params);
     boolean put(String url, Object params);
 }

--- a/ui/src/main/java/io/github/aosn/util/tryable/Failure.java
+++ b/ui/src/main/java/io/github/aosn/util/tryable/Failure.java
@@ -1,0 +1,54 @@
+package io.github.aosn.util.tryable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class Failure<T> implements Try<T> {
+    private final Throwable error;
+
+    Failure(Throwable t) {
+        this.error = t;
+    }
+
+    @Override
+    public T get() {
+        throw new UnsupportedOperationException("Failure doesn't have any value. This has a follow error: ", error);
+    }
+
+    @Override
+    public T orElseGet(T proxy) {
+        return proxy;
+    }
+
+    @Override
+    public T orElseThrow(Function<Throwable, RuntimeException> f) {
+        throw f.apply(error);
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Try<U> map(Function<T, U> f) {
+        return (Try<U>) this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Try<U> flatMap(Function<T, Try<U>> f) {
+        return (Try<U>) this;
+    }
+
+    @Override
+    public void forEach(Consumer<T> c) {
+    }
+
+    @Override
+    public Success<T> recover(Function<Throwable, T> f) {
+        return Try.succeeded(f.apply(error));
+    }
+
+}

--- a/ui/src/main/java/io/github/aosn/util/tryable/Success.java
+++ b/ui/src/main/java/io/github/aosn/util/tryable/Success.java
@@ -1,0 +1,52 @@
+package io.github.aosn.util.tryable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class Success<T> implements Try<T> {
+    private final T value;
+
+    Success(T value) {
+        this.value = value;
+    }
+
+    @Override
+    public T get() {
+        return value;
+    }
+
+    @Override
+    public T orElseGet(T proxy) {
+        return value;
+    }
+
+    @Override
+    public T orElseThrow(Function<Throwable, RuntimeException> f) {
+        return value;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return true;
+    }
+
+    @Override
+    public <U> Try<U> map(Function<T, U> f) {
+        return Try.succeeded(f.apply(value));
+    }
+
+    @Override
+    public <U> Try<U> flatMap(Function<T, Try<U>> f) {
+        return f.apply(value);
+    }
+
+    @Override
+    public void forEach(Consumer<T> c) {
+        c.accept(value);
+    }
+
+    @Override
+    public Success<T> recover(Function<Throwable, T> f) {
+        return this;
+    }
+}

--- a/ui/src/main/java/io/github/aosn/util/tryable/Supplier.java
+++ b/ui/src/main/java/io/github/aosn/util/tryable/Supplier.java
@@ -1,0 +1,12 @@
+package io.github.aosn.util.tryable;
+
+@FunctionalInterface
+public interface Supplier<T> {
+
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    T get() throws Throwable;
+}

--- a/ui/src/main/java/io/github/aosn/util/tryable/Try.java
+++ b/ui/src/main/java/io/github/aosn/util/tryable/Try.java
@@ -1,0 +1,34 @@
+package io.github.aosn.util.tryable;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface Try<T> {
+    T get();
+    T orElseGet(T proxy);
+    T orElseThrow(Function<Throwable, RuntimeException> f);
+    boolean isSuccess();
+    default boolean isFailure() {
+        return !isSuccess();
+    }
+    <U> Try<U> map(Function<T, U> f);
+    <U> Try<U> flatMap(Function<T, Try<U>> f);
+    void forEach(Consumer<T> c);
+    Success<T> recover(Function<Throwable, T> f);
+
+    static <T> Try<T> to(Supplier<T> f) {
+        try {
+            return succeeded(f.get());
+        } catch (Throwable t) {
+            return failed(t);
+        }
+    }
+
+    static <T> Success<T> succeeded(T value) {
+        return new Success<>(value);
+    }
+
+    static <T> Failure<T> failed(Throwable error) {
+        return new Failure<>(error);
+    }
+}

--- a/ui/src/main/java/io/github/aosn/util/tryable/Tryable.java
+++ b/ui/src/main/java/io/github/aosn/util/tryable/Tryable.java
@@ -1,0 +1,13 @@
+package io.github.aosn.util.tryable;
+
+public interface Tryable {
+    default <T> Try<T> Try(Supplier<T> f) {
+        return Try.to(f);
+    }
+    default <T> Try<T> Succeeded(T value) {
+        return Try.succeeded(value);
+    }
+    default <T> Try<T> Failed(Throwable error) {
+        return Try.failed(error);
+    }
+}


### PR DESCRIPTION
高階関数を扱う上ではチェック例外が厄介です。
値と例外を保持できるデータ型`Try`を追加して、例外をスローせず戻り値にすることで、チェック例外が発生する処理を単なる関数（`Function<?, Try<?>>`）として扱えるようになり、便利です。
